### PR TITLE
Stop using global config

### DIFF
--- a/git_advice.txt
+++ b/git_advice.txt
@@ -1,0 +1,4 @@
+Please stop breaking git in Pandon F1 by entering your details in the global config! 
+When entering your details please cd into your repository and use git config user.name "Test User"
+This will keep your configuration local to your repository and not ruin others repositories
+Do Not use --global as this means everyones projects check in and out with your username which can be very frustrating and cause issues


### PR DESCRIPTION
Please stop using the global config options, all of our commits are getting committed as you and its beginning to get very annoying having to clear the global config all of the time.

@joelohalleron 